### PR TITLE
Hotfix: display normal content when xAxis is not time in bar chart

### DIFF
--- a/src/components/DcCharts/chart-line/option.ts
+++ b/src/components/DcCharts/chart-line/option.ts
@@ -170,7 +170,7 @@ export function getOption(data: DC.StaticData, config: DC.ChartConfig = {}) {
         height: 25,
         start: 0,
         end: (xData && xData.length > 10) ? 500 / xData.length : 25,
-        labelFormatter: (_: any, value: string) => moment(Number(value)).format(moreThanOneDay ? moreThanOneDayFormat || 'M/D HH:mm' : 'HH:mm'),
+        labelFormatter: time ? (_: any, value: string) => moment(Number(value)).format(moreThanOneDay ? moreThanOneDayFormat || 'M/D HH:mm' : 'HH:mm') : null,
       }
       : false,
     grid: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30014895/124085565-c3c4f280-da82-11eb-903e-950c5d982e63.png)
