### PR TITLE
fix: add namespace to form explain

### DIFF
--- a/src/components/DcChartEditor/data-config/dice-form/index.scss
+++ b/src/components/DcChartEditor/data-config/dice-form/index.scss
@@ -21,6 +21,9 @@ $data-config-prefix-cls: #{$prefix}-dice-metrics-form;
   }
 }
 
-.pk-form-explain {
+.dc-dice-metrics-form {
+
+  .pk-form-explain {
   display: none;
+  }
 }


### PR DESCRIPTION
add the namespace to form explain