### PR TITLE
fix: i18n dashboard

### DIFF
--- a/src/components/DcChartEditor/data-config/dice-form/data-loader.ts
+++ b/src/components/DcChartEditor/data-config/dice-form/data-loader.ts
@@ -70,7 +70,7 @@ export const createLoadDataFn = ({
       const _valueDimensionMap = keyBy(_valueDimensions, 'key');
       const cols = map([..._typeDimensions, ..._valueDimensions], ({ key, alias, i18n }) => ({
         dataIndex: key,
-        title: i18n ? i18n.alias && i18n.alias[locale] : alias,
+        title: i18n?.alias?.[locale] ?? alias,
       }));
 
       return {
@@ -109,7 +109,7 @@ export const createLoadDataFn = ({
         metricData: map(_valueDimensions, (dimension) => {
           return {
             data: map(dataSource, (item) => item[dimension.key]),
-            name: dimension.i18n ? dimension.i18n.alias && dimension.i18n.alias[locale] : dimension.alias,
+            name: dimension?.i18n?.alias?.[locale] ?? dimension?.alias,
             ...dimension,
           };
         }),
@@ -122,7 +122,7 @@ export const createLoadDataFn = ({
   if (typeDimensionsLen === 0 && valueDimensionsLen > 0) {
     if (isBarType) {
       const { data: dataSource } = data;
-      const xData = map(_valueDimensions, (item) => (item.i18n ? item.i18n?.alias && item.i18n.alias[locale] : item.alias));
+      const xData = map(_valueDimensions, (item) => (item?.i18n?.alias?.[locale] ?? item?.alias));
 
       return {
         metricData: [{
@@ -139,16 +139,16 @@ export const createLoadDataFn = ({
         metricData: [{
           name: '',
           sort: 'none',
-          data: map(_valueDimensions, (item) => ({ name: item.i18n ? item.i18n.alias && item.i18n.alias[locale] : item.alias, value: dataSource[0][item.key] })),
+          data: map(_valueDimensions, (item) => ({ name: item?.i18n?.alias?.[locale] ?? item.alias, value: dataSource[0][item.key] })),
         }],
-        legendData: map(_valueDimensions, (item) => (item.i18n ? item.i18n.alias && item.i18n.alias[locale] : item.alias)),
+        legendData: map(_valueDimensions, (item) => (item?.i18n?.alias?.[locale] ?? item?.alias)),
         unit: _valueDimensions[0].unit,
       };
     }
     if (isMetricCardType) {
       const val = data.data[0];
       const metricData = map(_valueDimensions, (item) => ({
-        name: item.i18n ? item.i18n.alias && item.i18n.alias[locale] : item.alias,
+        name: item?.i18n?.alias?.[locale] ?? item?.alias,
         value: val[item.key],
         unit: item.unit,
       }));
@@ -159,7 +159,7 @@ export const createLoadDataFn = ({
 
       return {
         metricData: map(_valueDimensions, (item) => ({
-          name: item.i18n ? item.i18n.alias && item.i18n.alias[locale] : item.alias,
+          name: item?.i18n?.alias?.[locale] ?? item?.alias,
           data: map(dataSource, (dataItem) => ({
             name: dataItem[MAP_ALIAS],
             value: dataItem[item.key],
@@ -178,9 +178,9 @@ export const createLoadDataFn = ({
       return {
         metricData: [{
           name: alias,
-          data: map(dataSource, (item) => ({ name: i18n ? i18n[typeKey] && i18n[typeKey][locale] : item[typeKey], value: item[valueKey] })),
+          data: map(dataSource, (item) => ({ name: i18n?.[typeKey]?.[locale] ?? item[typeKey], value: item[valueKey] })),
         }],
-        legendData: map(dataSource, (item) => (i18n ? i18n[typeKey] && i18n[typeKey][locale] : item[typeKey])),
+        legendData: map(dataSource, (item) => (i18n?.[typeKey]?.[locale] ?? item[typeKey])),
         unit,
       };
     }
@@ -190,8 +190,8 @@ export const createLoadDataFn = ({
       const { key: valueKey, unit, i18n } = _valueDimensions[0];
 
       return {
-        metricData: map(dataSource, (item) => ({ name: i18n ? i18n[typeKey] && i18n[typeKey][locale] : item[typeKey], value: item[valueKey], unit })),
-        legendData: map(dataSource, (item) => (i18n ? i18n[typeKey] && i18n[typeKey][locale] : item[typeKey])),
+        metricData: map(dataSource, (item) => ({ name: i18n?.[typeKey]?.[locale] ?? item[typeKey], value: item[valueKey], unit })),
+        legendData: map(dataSource, (item) => (i18n?.[typeKey]?.[locale] ?? item[typeKey])),
       };
     }
   }
@@ -207,7 +207,7 @@ export const createLoadDataFn = ({
       const otherDimensions = dropWhile(_typeDimensions, { type: 'time' });
       const time = map(uniqBy(dataSource, timeDimension.key), (item) => item[timeDimension.key]);
       const groups = chunk(dataSource, time.length);
-      const alias = valueDimension.i18n ? valueDimension.i18n.alias && valueDimension.i18n.alias[locale] : valueDimension.alias;
+      const alias = valueDimension?.i18n?.alias?.[locale] ?? valueDimension?.alias;
       const metricData = map(groups, (group) => {
         const nameItem: any = find(group, (item: any) => (!!item[valueDimension.key] || isNumber(item[valueDimension.key])) && Object.values(item).every((value) => value !== null)) || {};
         return {
@@ -244,7 +244,7 @@ export const createLoadDataFn = ({
             data: map(group, (item: any) => item[valueDimension.key]),
             name: reduce(otherDimensions, (name, { key }, index) => `${name}${nameItem[key]}${index !== otherDimensions.length - 1 ? ' / ' : ''}`, ''),
             ...valueDimension,
-            alias: valueDimension.i18n ? valueDimension.i18n.alias && valueDimension.i18n.alias[locale] : valueDimension.alias,
+            alias: valueDimension?.i18n?.alias?.[locale] ?? valueDimension?.alias,
           });
         });
       });
@@ -252,7 +252,7 @@ export const createLoadDataFn = ({
       return {
         metricData,
         time,
-        valueNames: _valueDimensions.map((x) => (x.i18n ? x.i18n.alias && x.i18n.alias[locale] : x.alias)),
+        valueNames: _valueDimensions.map((x) => (x?.i18n?.alias?.[locale] ?? x.alias)),
       };
     }
   }

--- a/src/components/DcChartEditor/data-config/dice-form/types/index.d.ts
+++ b/src/components/DcChartEditor/data-config/dice-form/types/index.d.ts
@@ -25,6 +25,11 @@ declare namespace DICE_DATA_CONFIGURATOR {
     unit: string;
   }
 
+  interface I18n {
+    zh: string;
+    en: string;
+  }
+
   interface ValueDimension {
     /**
      *列表唯一 key
@@ -47,6 +52,17 @@ declare namespace DICE_DATA_CONFIGURATOR {
      * @memberof ValueDimension
      */
     alias: string;
+    /**
+     *国际化
+     *
+     * @type {object}
+     * @memberof ValueDimension
+     */
+    i18n?: {
+      alias?: I18n;
+      title?: I18n;
+      description?: I18n;
+    };
     /**
      *指标，type 为 field 时必须
      *

--- a/src/components/DcContainer/index.tsx
+++ b/src/components/DcContainer/index.tsx
@@ -225,7 +225,7 @@ const DcContainer: React.FC<IProps> = ({
         </When>
         <Otherwise>
           <div className="flex-box">
-            <h2 className="dc-chart-title px12">{i18n ? i18n.title && i18n.title[locale] : title} </h2>
+            <h2 className="dc-chart-title px12">{i18n?.title?.[locale] ?? title} </h2>
             <div className={classnames({ 'dc-chart-options': true, 'visibility-hidden': !isEditMode })}>
               <If condition={isEditMode && !chartEditorVisible && !isFullscreen}>
                 <Tooltip title={textMap['config charts']}>
@@ -233,7 +233,7 @@ const DcContainer: React.FC<IProps> = ({
                 </Tooltip>
               </If>
               <If condition={description}>
-                <Tooltip title={i18n ? i18n.description && i18n.description[locale] : description}>
+                <Tooltip title={i18n?.description?.[locale] ?? description}>
                   <Button type="text"><DcIcon type="info-circle" /></Button>
                 </Tooltip>
               </If>

--- a/src/components/DcContainer/index.tsx
+++ b/src/components/DcContainer/index.tsx
@@ -51,10 +51,11 @@ const DcContainer: React.FC<IProps> = ({
   const { toggleFullscreen: toggleFromEditorPureFullscreen, editView, checkBeforeSave } = ChartEditorStore;
   const isFullscreen = isPure ? fromPureFullscreenStatus : fromEditorFullscreenStatus;
   const toggleFullscreen = isPure ? togglePureFullscreen : toggleFromEditorPureFullscreen;
-  const textMap = DashboardStore.getState((s) => s.textMap);
+  const [textMap, locale] = DashboardStore.getState((s) => [s.textMap, s.locale]);
 
   const {
     title: _title,
+    i18n,
     description: _description,
     chartType,
     hideHeader = false,
@@ -224,7 +225,7 @@ const DcContainer: React.FC<IProps> = ({
         </When>
         <Otherwise>
           <div className="flex-box">
-            <h2 className="dc-chart-title px12">{title}</h2>
+            <h2 className="dc-chart-title px12">{i18n ? i18n.title && i18n.title[locale] : title} </h2>
             <div className={classnames({ 'dc-chart-options': true, 'visibility-hidden': !isEditMode })}>
               <If condition={isEditMode && !chartEditorVisible && !isFullscreen}>
                 <Tooltip title={textMap['config charts']}>
@@ -232,7 +233,7 @@ const DcContainer: React.FC<IProps> = ({
                 </Tooltip>
               </If>
               <If condition={description}>
-                <Tooltip title={description}>
+                <Tooltip title={i18n ? i18n.description && i18n.description[locale] : description}>
                   <Button type="text"><DcIcon type="info-circle" /></Button>
                 </Tooltip>
               </If>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -13,6 +13,11 @@ declare namespace DC {
     dimensions: any[];
   }
 
+  interface I18n {
+    zh: string;
+    en: string;
+  }
+
   type DataConvertor = (data: object) => object;
   type OptionFn = (data: object, optionExtra?: object) => object;
 
@@ -117,6 +122,10 @@ declare namespace DC {
     name: string;
     description?: string;
     title?: string | (() => ReactNode);
+    i18n?: {
+      title?: I18n;
+      description?: I18n;
+    };
     /** 组件类型，图表或其他，界面配置时内置为chart:xxx类型; 注册了其他组件后可选择 */
     chartType: ViewType;
     /** 地图层级，需要迁到其他地方 */


### PR DESCRIPTION
The back-end will respond like ：
![image](https://user-images.githubusercontent.com/30014895/131332893-6471801c-8085-4f9d-acd4-86c129c71edf.png)
```
i18n: {
   key: {
      zh: 'xxxx',
      ch: 'xxxx',
   }
}
```