### PR TITLE
fix: collapse page in safari under v13.1

### DIFF
--- a/src/common/utils/replace-variable.ts
+++ b/src/common/utils/replace-variable.ts
@@ -18,7 +18,7 @@ function replaceVariable(source: any, variable?: Record<string, any>): any {
     return matchItems.reduce((acc: string, current: string) => {
       const val = variable[current.slice(2, -2)]
         || (source.length > current.length ? '' : undefined);
-      return (val || val === '') ? acc.replaceAll(current, val) : undefined;
+      return (val || val === '') ? acc.replace(current, val) : undefined;
     }, source);
   } else if (type != null && type === 'object') {
     const result = produce(source, (draft: { [x: string]: any }) => {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor

## What this PR does / why we need it:
fix that collapse page in safari under v13.1 for it can't support replaceAll

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
fix that collapse page in safari under v13.1 for it can't support replaceAll

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


