### PR TITLE
fix: one y axis as default config

### DIFF
--- a/src/components/DcCharts/chart-line/option.ts
+++ b/src/components/DcCharts/chart-line/option.ts
@@ -51,11 +51,12 @@ export function getOption(data: DC.StaticData, config: DC.ChartConfig = {}) {
       : dataList;
   };
   map(metricData, (value, i) => {
+    const yIndex = option?.yAxis?.[i] ? i : 0;
     const { axisIndex, name, tag, alias = '', unit: _unit, ...rest } = value;
     if (tag || name) {
       legendData.push({ name: tag || name });
     }
-    const yAxisIndex = axisIndex || 0;
+    const yAxisIndex = yIndex || 0;
     const areaColor = areaColors[i];
 
     const normalSeriesData = isMultipleTypeAndMultipleValue

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -89,6 +89,7 @@ declare namespace DC {
     yAxisNames?: string[];
     legendFormatter?: Function;
     timeSpan?: any;
+    yAxis?: object[];
   }
 
   interface MetricData {


### PR DESCRIPTION
## What type of PR is this?

- [x] Feature
- [x] Bugfix
- [ ] Test
- [ ] Documentation
- [ ] Refactor

## What this PR does / why we need it:
one y-axis as default config unless option was covered to set multiple  Y axes

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a screenshot is required:
-->
- [ ] Yes(screenshot is required)
- [ ] No


## Special notes for your reviewer:


